### PR TITLE
Feature logging

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,27 @@
+local.file_match "applogs" {
+    path_targets = [
+        { 
+            __path__ = "/app/logs/user-service/*.log",
+            service  = "user-service",
+        },
+        { 
+            __path__ = "/app/logs/room-service/*.log",
+            service  = "room-service",
+        },
+        { 
+            __path__ = "/app/logs/reservation-service/*.log",
+            service  = "reservation-service",
+        },
+    ]
+}
+
+loki.source.file "files" {
+    targets    = local.file_match.applogs.targets
+    forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+    endpoint {
+        url = "http://loki:3100/loki/api/v1/push"
+    }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,7 @@ services:
     volumes:
       - ${USER_SERVICE_PATH}/keys/private_key.key:/app/keys/private_key.key:ro
       - ${USER_SERVICE_PATH}/keys/public_key.pem:/app/keys/public_key.pem:ro
+      - ./logs/user-service:/app/logs
     healthcheck:
       test:
         [
@@ -81,6 +82,7 @@ services:
     volumes:
       - ${ROOM_SERVICE_PATH}/keys/public_key.pem:/app/keys/public_key.pem:ro
       - ${ROOM_SERVICE_PATH}/nginx/images:/app/images/
+      - ./logs/room-service:/app/logs
     healthcheck:
       test:
         [
@@ -147,6 +149,7 @@ services:
         condition: service_healthy
     volumes:
       - ${RESERVATION_SERVICE_PATH}/keys/public_key.pem:/app/keys/public_key.pem:ro
+      - ./logs/reservation-service:/app/logs
     healthcheck:
       test:
         [
@@ -220,6 +223,11 @@ services:
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./grafana/dashboards:/var/lib/grafana/dashboards
     restart: always
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
 
 volumes:
   user_pgdata:

--- a/compose.yml
+++ b/compose.yml
@@ -229,6 +229,14 @@ services:
     ports:
       - "3100:3100"
 
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ./logs:/app/logs
+      - ./alloy/config.alloy:/etc/alloy/config.alloy
+    ports:
+      - "12345:12345"
+
 volumes:
   user_pgdata:
     name: bookem-user-service-db-volume

--- a/grafana/provisioning/datasources/loki.yml
+++ b/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,12 @@
 
 set -e
 
+# Create log directories
+
+mkdir -p ./logs/user-service
+mkdir -p ./logs/room-service
+mkdir -p ./logs/reservation-service
+
 # Load env vars safely
 ENV_FILES=(
   "./default.env"


### PR DESCRIPTION
Closes #23 

Part of:
- https://github.com/book-em/room-service/pull/23
- https://github.com/book-em/user-service/pull/29
- https://github.com/book-em/reservation-service/pull/11
- https://github.com/book-em/infrastructure/pull/24

Alloy collects logs from specified sources and then passes it to some other "thing" in the network.
Note that we would normally use Promtail and not Alloy, but Promtail is deprecated and is reaching End Of Life soon.

Loki collects logs, aggregates them and ultimately allows us to preview logs in Grafana. 

**How to use**

1. Run the infrastructure (`./run.sh`)
2. Go to the Grafana dashboard (localhost:3000)
3. Go to "Data Sources" and select Loki's "Explore" button.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/38bf2adb-ce4e-48ea-822c-79ef56e84b40" />

4. Select the Query Builder, create a basic query (by fetching all logs with a specific label) and hit run.
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e36d03b5-9f74-463d-80e0-aa7f14f0fa65" />

5. You should get results like these:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/083aecd5-3a30-408c-9ee1-28fe4e360c9f" />

Most of the logs are from the `/healthz` endpoint, but if you use the web app you'll see the other logs.

---

Here's the explanation for the Alloy configuration.

```c

// Create "applogs" as a worker that matches for files in a local directory.
// For each of those we specify its __path__ as a pattern (so we collect from /app/logs which is
// mounted with Docker Compose from the local ./logs/...).
// We also specify a custom label called "service" which we can use to do queries later.

local.file_match "applogs" {
    path_targets = [
        { 
            __path__ = "/app/logs/user-service/*.log",
            service  = "user-service",
        },
        { 
            __path__ = "/app/logs/room-service/*.log",
            service  = "room-service",
        },
        { 
            __path__ = "/app/logs/reservation-service/*.log",
            service  = "reservation-service",
        },
    ]
}

// For Loki, we declare "files" which takes files created by "applogs", 
// takes its labels (including "service") and passes them along to a 
.. receiver of "default" which is defined below.

loki.source.file "files" {
    targets    = local.file_match.applogs.targets
    forward_to = [loki.write.default.receiver]
}

// "default" is a Loki writer. It deals with sending logs to Loki.
// We need to specify its endpoint.

loki.write "default" {
    endpoint {
        url = "http://loki:3100/loki/api/v1/push"
    }
}
```